### PR TITLE
Updated YandexCaptcha validation URL and added exception handling

### DIFF
--- a/src/Rules/YandexCaptcha.php
+++ b/src/Rules/YandexCaptcha.php
@@ -3,20 +3,35 @@
 namespace Dsoloview\YandexCaptcha\Rules;
 
 use Closure;
+use Exception;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 class YandexCaptcha implements ValidationRule
 {
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        $args = http_build_query([
-            'secret' => config('yandex_captcha.server_key'),
-            'token' => $value,
-            'ip' => request()->ip(),
-        ]);
+        try {
+            $response = Http::get(
+                'https://smartcaptcha.yandexcloud.net/validate',
+                [
+                    'secret' => config('yandex_captcha.server_key'),
+                    'token' => $value,
+                    'ip' => request()->ip(),
+                ],
+            );
+        } catch (Exception $e) {
+            Log::error(
+                "Unknown error occured during checking Yandex SmartCaptcha: {$e->getMessage()}",
+                [
+                    'method' => __METHOD__,
+                    'exception' => $e,
+                ],
+            );
 
-        $response = Http::get('https://smartcaptcha.yandexcloud.net/validate', $args);
+            return;
+        }
 
         if ($response->status() !== 200) {
             $fail('Error with Yandex SmartCaptcha validation');

--- a/src/Rules/YandexCaptcha.php
+++ b/src/Rules/YandexCaptcha.php
@@ -16,7 +16,7 @@ class YandexCaptcha implements ValidationRule
             'ip' => request()->ip(),
         ]);
 
-        $response = Http::get('https://captcha-api.yandex.ru/validate', $args);
+        $response = Http::get('https://smartcaptcha.yandexcloud.net/validate', $args);
 
         if ($response->status() !== 200) {
             $fail('Error with Yandex SmartCaptcha validation');


### PR DESCRIPTION
### Changes
- Updated the URL for the Yandex SmartCaptcha request in `YandexCaptchaRule`.
- Added exception handling for network errors:
  - Connection and timeout errors are now logged.
  - In case of an exception, CAPTCHA validation **does not block the form** (skips without calling `$fail()`).
- Simplified `Http::get()` usage without `http_build_query`.

### Why
Previously, if the URL changed or the Yandex SmartCaptcha server was unavailable, the validation would fail entirely.  
Now the system is more resilient to temporary network issues and logs problems without affecting the user experience.
